### PR TITLE
Correct typo for Celsius

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -271,7 +271,7 @@
             <label id="tempLabel" for="tUnits">Temp Units:</label>
             <select name="tUnits" id="tUnits">
                 <option value="f">Fahrenheit</option>
-                <option value="c">Celcius</option>
+                <option value="c">Celsius</option>
             </select>
             <button id="timezoneSet" onclick="setTempUnits()">Set Temp Units</button>
         </div>


### PR DESCRIPTION
Small typo of Celsius in wired (image one), this fixes that (image 2).
<img width="174" height="154" alt="image" src="https://github.com/user-attachments/assets/1394d209-d482-48dc-8d07-dc251d75a267" />

<img width="171" height="166" alt="image" src="https://github.com/user-attachments/assets/788e7ce9-66d7-4752-a6d1-b5cdbb6f516d" />
